### PR TITLE
Feature/authorization rules

### DIFF
--- a/.idea/rails_blog_pj.iml
+++ b/.idea/rails_blog_pj.iml
@@ -32,6 +32,7 @@
     <orderEntry type="library" scope="PROVIDED" name="bootstrap_form (v5.4.0, rbenv: 3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="builder (v3.2.4, rbenv: 3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bundler (v2.4.19, rbenv: 3.2.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="cancancan (v3.5.0, rbenv: 3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="capybara (v3.39.2, rbenv: 3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.2.2, rbenv: 3.2.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="connection_pool (v2.4.1, rbenv: 3.2.2) [gem]" level="application" />

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '3.2.2'
 gem 'bootstrap_form', '~> 5.4'
+gem 'cancancan'
 gem 'kaminari'
 gem 'launchy', '~> 2.4', '>= 2.4.3'
 gem 'rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,7 @@ GEM
       actionpack (>= 6.1)
       activemodel (>= 6.1)
     builder (3.2.4)
+    cancancan (3.5.0)
     capybara (3.39.2)
       addressable
       matrix
@@ -337,6 +338,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   bootstrap_form (~> 5.4)
+  cancancan
   capybara
   cssbundling-rails (~> 1.3)
   debug

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,13 @@
 class ApplicationController < ActionController::Base
-  before_action :current_user
+  include CanCan::ControllerAdditions
+  protect_from_forgery with: :exception
+  before_action :update_allowed_parameters, if: :devise_controller?
+  # check_authorization unless: :devise_controller?
 
-  private
+  protected
 
-  def current_user
-    @current_user = User.first
+  def update_allowed_parameters
+    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name, :email, :password, :role) }
+    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :email, :password, :current_password) }
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,7 @@
 class CommentsController < ApplicationController
-  before_action :set_user_and_post
+  before_action :set_user_and_post, only: %i[new create]
+  before_action :authenticate_user!, only: %i[create destroy]
+  load_and_authorize_resource
 
   def new
     @comment = Comment.new
@@ -7,7 +9,7 @@ class CommentsController < ApplicationController
 
   def create
     @comment = Comment.new(comment_params)
-    @comment.user_id = User.first.id
+    @comment.user_id = current_user.id
     @comment.post_id = @post.id
 
     if @comment.save
@@ -15,6 +17,14 @@ class CommentsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+    @post = @comment.post
+    @post.decrement!(:comments_counter)
+    @comment.destroy!
+    redirect_to user_post_path(id: @post.id), notice: 'Comment deleted'
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,8 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!, only: %i[create destroy]
+  load_and_authorize_resource
+  before_action :set_user, only: %i[new create]
+
   def index
     @user = User.find(params[:user_id])
     @posts = @user.posts.includes(:author, :comments, :likes).page(params[:page]).per(10)
@@ -25,11 +29,23 @@ class PostsController < ApplicationController
     else
       render :new
     end
+
+    def destroy # rubocop:disable Lint/NestedMethodDefinition
+      @post = Post.find(params[:id])
+      author = @post.author
+      author.decrement!(:posts_counter)
+      @post.destroy!
+      redirect_to user_posts_path(id: author.id), notice: 'Post deleted!'
+    end
   end
 
   private
 
   def post_params
     params.require(:post).permit(:title, :text)
+  end
+
+  def set_user
+    @user = User.find(params[:user_id])
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -29,14 +29,16 @@ class PostsController < ApplicationController
     else
       render :new
     end
+  end
 
-    def destroy # rubocop:disable Lint/NestedMethodDefinition
-      @post = Post.find(params[:id])
-      author = @post.author
-      author.decrement!(:posts_counter)
-      @post.destroy!
-      redirect_to user_posts_path(id: author.id), notice: 'Post deleted!'
-    end
+  def destroy
+    authenticate_user!
+
+    @post = Post.find(params[:id])
+    author = @post.author
+    author.decrement!(:posts_counter)
+    @post.destroy!
+    redirect_to user_posts_path(id: author.id), notice: 'Post deleted!'
   end
 
   private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the user here. For example:
+    #
+    #   return unless user.present?
+    #   can :read, :all
+    #   return unless user.admin?
+    #   can :manage, :all
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, published: true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,32 +1,20 @@
-# frozen_string_literal: true
-
 class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the user here. For example:
-    #
-    #   return unless user.present?
-    #   can :read, :all
-    #   return unless user.admin?
-    #   can :manage, :all
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, published: true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/blob/develop/docs/define_check_abilities.md
+    if user.role == 'admin'
+      can :manage, :all
+    else
+      can :read, :all
+      can :create, Post, author_id: user.id
+      can :create, Comment, user_id: user.id
+      can :create, Like
+      can :destroy, Comment do |item|
+        item.user_id == user.id
+      end
+      can :destroy, Post do |item|
+        item.author_id == user.id
+      end
+    end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :author, class_name: 'User', foreign_key: :author_id
-  has_many :likes, foreign_key: :post_id
-  has_many :comments, foreign_key: :post_id
+  has_many :likes, foreign_key: :post_id, dependent: :destroy
+  has_many :comments, foreign_key: :post_id, dependent: :destroy
 
   after_save :update_post_counter
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,10 @@
 class User < ApplicationRecord
   has_many :posts, foreign_key: :author_id
-  has_many :comments, foreign_key: :user_id
-  has_many :likes, foreign_key: :user_id
+  has_many :comments, foreign_key: :user_id, dependent: :destroy
+  has_many :likes, foreign_key: :user_id, dependent: :destroy
 
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable, :confirmable, :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :confirmable,
+         :recoverable, :rememberable, :validatable
 
   def recent_posts
     posts.order(created_at: :desc).limit(3)

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -19,7 +19,7 @@
         <div class="mb-3">
           <%= f.label :photo, class: "form-label" %>
           <%= f.text_field :photo, autofocus: true, autocomplete: "photo", placeholder: "profile picture url", class: "form-control" %>
-          <%= f.hidden_field :photo, value: "https://previews.123rf.com/images/valentint/valentint1406/valentint140601650/29505264-perfil-de-usuario-icono-bot%C3%B3n-met%C3%A1lico-de-internet-sobre-fondo-blanco.jpg" %>
+          <%= f.hidden_field :photo, value: "https://i.stack.imgur.com/l60Hf.png" %>
           <small class="form-text text-muted">(leave it blank to use default picture)</small>
         </div>
         <div class="mb-3">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -25,7 +25,12 @@
   </div>
 
   <div class="d-flex justify-content-center likes my-2">
-    <%= render 'shared/likes_form' %>
+    <div class="col-12 text-center d-flex justify-content-center">
+      <% if user_signed_in? && can?(:destroy, @post) %>
+        <%= button_to 'Like', user_post_likes_path(@post.author, @post), method: :post, class: "btn btn-primary mx-1" %>
+        <%= button_to 'Delete post', user_post_path(@post.author, @post), method: :delete, class: "btn btn-danger mx-1" %>
+      <% end %>
+    </div>
   </div>
 
   <div class="d-flex justify-content-center likes">
@@ -42,6 +47,12 @@
           <% @post.recent_comments.each do |comment| %>
             <li>
               <strong><%= comment.user.name %>:</strong> <%= comment.text %>
+              <% if user_signed_in? && can?(:destroy, comment) %>
+                <%= button_to 'Delete comment',
+                              user_post_comment_path(@post.author, comment.post, comment),
+                              method: :delete,
+                              class: "btn btn-danger mx-1" %>
+              <% end %>
             </li>
           <% end %>
         <% end %>
@@ -51,5 +62,6 @@
 
   <div class="d-flex justify-content-around my-3 text-center">
     <%= link_to "Back to all users", users_path(@user), class: "btn btn-primary" %>
+    <%= link_to "Back to User Details", user_path(@user), class: "btn btn-primary" %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -19,8 +19,8 @@
             <%= @user.name %>
           </h3>
           <p class="user-posts text-end m-0">
-            <a href="<%= user_posts_path(@user) %>" title="To User Posts" class="unstyled">Number of posts: <%= @user.posts_counter %></a> <br>
-            <a href="<%= user_posts_path(@user) %>" title="To User Posts" class="unstyled">See all post: <%= @user.posts_counter %></a>
+            <a href="<%= user_posts_path(@user) %>" title="To User Posts" class="unstyled">See All Posts</a> <br>
+            <%= link_to 'New Post', new_user_post_path(@user), class: 'btn btn-success my-2 text-center' %>
           </p>
         </div>
       </div>
@@ -47,7 +47,7 @@
       <% recent_posts.each do |post| %>
         <div class="col-sm-12 border rounded my-3">
           <h5 class="user-name py-3">
-            Post #<%= post.id %>
+            <%= link_to "Post #{post.id}", user_post_path(user_id: @user.id, id: post.id), title: "To Post Details", class: "unstyled"%>
           </h5>
           <h3 class="user-name">
             <%= post.title %>
@@ -69,8 +69,8 @@
   <div class="row">
     <div class="col">
       <div class="d-flex justify-content-around my-3 text-center">
-        <%= link_to "See all users", users_path(@user), class: "btn btn-primary" %>
-        <%= link_to "See all posts", user_posts_path(@user), class: "btn btn-primary all-post" %>
+        <%= link_to "See all users", users_path(@user), class: "btn btn-dark" %>
+        <%= link_to "See all posts", user_posts_path(@user), class: "btn btn-dark all-post" %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -69,8 +69,8 @@
   <div class="row">
     <div class="col">
       <div class="d-flex justify-content-around my-3 text-center">
-        <%= link_to "See all users", users_path(@user), class: "btn btn-dark" %>
-        <%= link_to "See all posts", user_posts_path(@user), class: "btn btn-dark all-post" %>
+        <%= link_to "See all users", users_path(@user), class: "btn btn-primary" %>
+        <%= link_to "See all posts", user_posts_path(@user), class: "btn btn-primary all-post" %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
-  devise_for :users, controllers: { registrations: 'users/registrations' }
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
   root 'users#index'
 
   resources :users, only: [:index, :show] do
-    resources :posts, except: [:edit, :update, :destroy] do
-      resources :comments, only: [:new, :create]
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
+      resources :comments, only: [:new, :create, :destroy]
       resources :likes, only: [:create]
     end
   end

--- a/db/migrate/20231117203036_add_role_to_users.rb
+++ b/db/migrate/20231117203036_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :role, :string
+  end
+end

--- a/db/migrate/20231117203036_add_role_to_users.rb
+++ b/db/migrate/20231117203036_add_role_to_users.rb
@@ -1,5 +1,5 @@
 class AddRoleToUsers < ActiveRecord::Migration[7.1]
   def change
-    add_column :users, :role, :string
+    add_column :users, :role, :string, default: 'user'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_16_213208) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_17_203036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_16_213208) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,7 +15,8 @@ first_user = User.create(
   'password' => 'password',
   'photo' => 'https://i.pravatar.cc/150?img=3',
   'bio' => 'Michael is a distinguished historian specializing in medieval Europe. Born in London in 1978, he developed an interest in history at a young age. He earned his Ph.D. in Medieval Studies from Oxford University and has since published several acclaimed books on the Crusades. Michael is also known for his engaging lectures and commitment to making history accessible to a wider audience.',
-  'confirmed_at' => Time.now)
+  'confirmed_at' => Time.now,
+  'role' => 'user')
 
 second_user = User.create(
   'name' => 'Sarah Patel',
@@ -23,7 +24,9 @@ second_user = User.create(
   'password' => 'password',
   'photo' => 'https://i.pravatar.cc/150?img=25',
   'bio' => 'Sarah is an influential software engineer and tech entrepreneur from Mumbai, born in 1982. She co-founded a leading AI startup that revolutionized machine learning applications in healthcare. Sarah is a prominent advocate for women in technology and has been featured in numerous tech conferences as a keynote speaker.',
-  'confirmed_at' => Time.now)
+  'confirmed_at' => Time.now,
+  'role' => 'admin')
+
 
 third_user = User.create(
   'name' => 'Nina Nguyen',
@@ -31,7 +34,8 @@ third_user = User.create(
   'password' => 'password',
   'photo' => 'https://i.pravatar.cc/150?img=20',
   'bio' => 'Nina is a Vietnamese-American film director born in 1976 in Ho Chi Minh City. She moved to Los Angeles as a child and later attended NYU\'s Tisch School of the Arts. Her films, known for their powerful storytelling and visual artistry, have won multiple awards at international film festivals.',
-  'confirmed_at' => Time.now)
+  'confirmed_at' => Time.now,
+  'role' => 'user')
 
 fourth_user = User.create(
   'name' => 'Emma Johnson',
@@ -39,7 +43,8 @@ fourth_user = User.create(
   'password' => 'password',
   'photo' => 'https://i.pravatar.cc/150?img=47',
   'bio' => 'Emma is a Canadian environmental scientist born in Toronto in 1985. Her groundbreaking research on climate change and its impact on Arctic ecosystems has been widely recognized. Emma is an advocate for sustainable practices and has worked with various NGOs to promote environmental awareness and policy change.',
-  'confirmed_at' => Time.now)
+  'confirmed_at' => Time.now,
+  'role' => 'user')
 
 ### Posts ###
 first_post = Post.create(author: first_user, 'title' => 'Post 1', 'text' => 'This is the text of post 1')


### PR DESCRIPTION
✨ Enhance User Permissions with CanCanCan ✨

This pull request introduces enhanced user permissions using CanCanCan to control post and comment deletion actions.

Highlights:

🆕 Added a role column to the users table to manage user permissions.
🔐 Implemented CanCanCan authorization for post and comment deletion.
🚮 Added "Delete" buttons to the post and comment views, visible only to authorized users.
Detailed Changes:

1. Install CanCanCan:
- [X] Installed the CanCanCan gem and its dependencies.

2. Add Role Column:
- [X] Added a role column to the users table to store user roles.
- [X] Migrated the database schema to accommodate the new column.

3. Post Deletion with CanCanCan:
- [X] Implemented CanCanCan authorization for post deletion actions.
- [X] Users can delete their own posts or posts if they have an admin role.
- [X] Added a "Delete" button to the post view, visible only to authorized users.

4. Comment Deletion with CanCanCan:
- [X] Implemented CanCanCan authorization for comment deletion actions.
- [X] Users can delete their own comments or comments if they have an admin role.
- [X] Added a "Delete" button to the comment view, visible only to authorized users.

This pull request enhances the project's user permission system, enabling granular control over post and comment deletion actions. 🎉